### PR TITLE
Added content accessible to workaround security error in firefox

### DIFF
--- a/Firefox/chrome.manifest
+++ b/Firefox/chrome.manifest
@@ -1,4 +1,4 @@
-content   livereload                 content/
+content   livereload                 content/ contentaccessible=yes
 skin      livereload   classic/1.0   skin/
 
 overlay   chrome://browser/content/browser.xul   chrome://livereload/content/browser.xul


### PR DESCRIPTION
Here is a fix for following issue, I've encountered myself.

http://stackoverflow.com/questions/6964724/loading-a-javascript-into-head-by-its-chrome-url
