### PR TITLE
Add support for hi resolution icons in the LR Chrome extension

### DIFF
--- a/src/global-chrome.coffee
+++ b/src/global-chrome.coffee
@@ -14,7 +14,7 @@ ToggleCommand =
   update: (tabId) ->
     status = LiveReloadGlobal.tabStatus(tabId)
     chrome.browserAction.setTitle { tabId, title: status.buttonToolTip }
-    chrome.browserAction.setIcon { tabId, path: status.buttonIcon }
+    chrome.browserAction.setIcon { tabId, path: { '19' : status.buttonIcon, '38' : status.buttonIconHiRes } }
 
 
 chrome.browserAction.onClicked.addListener (tab) ->

--- a/src/global.coffee
+++ b/src/global.coffee
@@ -7,18 +7,22 @@ Status =
     buttonEnabled: no
     buttonToolTip: 'LiveReload not available on this tab'
     buttonIcon: 'IconUnavailable.png'
+    buttonIconHiRes: 'IconUnavailable@2x.png'
   disabled:
     buttonEnabled: yes
     buttonToolTip: 'Enable LiveReload'
     buttonIcon: 'IconDisabled.png'
+    buttonIconHiRes: 'IconDisabled@2x.png'
   enabled:
     buttonEnabled: yes
     buttonToolTip: 'LiveReload is connecting, click to disable'
     buttonIcon: 'IconEnabled.png'
+    buttonIconHiRes: 'IconEnabled@2x.png'
   active:
     buttonEnabled: yes
     buttonToolTip: 'LiveReload is connected, click to disable'
     buttonIcon: 'IconActive.png'
+    buttonIconHiRes: 'IconActive@2x.png'
 
 
 


### PR DESCRIPTION
Modifies the `setIcon` function to include paths to both the 19px icon and the 38px icon as described here [https://developer.chrome.com/extensions/browserAction.html#method-setIcon](https://developer.chrome.com/extensions/browserAction.html#method-setIcon) because Chrome extensions don't automagically pick up `@2x` images.

Using the icons from #21 works too!