### PR TITLE
Update global.coffee

### DIFF
--- a/src/common/global.coffee
+++ b/src/common/global.coffee
@@ -190,7 +190,7 @@ LiveReloadGlobal =
         xhr.onerror = (event) =>
           callback('cannot-download') unless callbackCalled
           callbackCalled = yes
-        xhr.open("GET", "http://#{@host}:#{@port}/livereload.js", true)
+        xhr.open("GET", "//#{@host}:#{@port}/livereload.js", true)
         xhr.send(null)
 
 


### PR DESCRIPTION
Making the livereload.js resource URL protocol-relative. This adds support for running livereload on https.
